### PR TITLE
Eclipse project generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /target/
+.classpath
+.project
+.settings
+

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,16 @@
                     </includes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-eclipse-plugin</artifactId>
+                <version>2.8</version>
+                <configuration>
+                    <downloadSources>true</downloadSources>
+                    <downloadJavadocs>true</downloadJavadocs>
+                    <useProjectReferences>false</useProjectReferences>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>


### PR DESCRIPTION
Configure the pom.xml file to generate slightly more complete Eclipse projects,
when people run `mvn eclipse:eclipse`. Also add the Eclipse project files to
.gitignore so people are less likely to mistakenly commit them.
