### PR TITLE
Undo APIs

### DIFF
--- a/src/main/java/journal/io/api/Journal.java
+++ b/src/main/java/journal/io/api/Journal.java
@@ -661,7 +661,7 @@ public class Journal {
         return currentUserRecord;
     }
 
-    public class Redo implements Iterable<Location> {
+    private class Redo implements Iterable<Location> {
 
         private final Location start;
 
@@ -708,7 +708,7 @@ public class Journal {
         }
     }
 
-    static class Undo implements Iterable<Location> {
+    private class Undo implements Iterable<Location> {
         private final Object[] stack;
         private final int start;
   
@@ -741,6 +741,7 @@ public class Journal {
             return new Iterator<Location>() {
                 private int pointer = start;
                 private Object[] ref = stack;
+                private Location current;
       
                 @Override
                 public boolean hasNext() {
@@ -759,11 +760,20 @@ public class Journal {
                         return next();
                     }
                     pointer++;
-                    return (Location) next;
+                    return current = (Location) next;
                 }
       
                 @Override
                 public void remove() {
+                    if (current == null) {
+                        throw new IllegalStateException("No location to remove!");
+                    }
+                    try {
+                        delete(current);
+                        current = null;
+                    } catch (IOException e) {
+                        throw new IllegalStateException(e.getMessage(), e);
+                    }
                 }
             };
         }

--- a/src/main/java/journal/io/api/Journal.java
+++ b/src/main/java/journal/io/api/Journal.java
@@ -282,10 +282,25 @@ public class Journal {
         return new Redo(start);
     }
     
+    /**
+     * Return an iterable to replay the journal in reverse, starting with the
+     * newest location and ending with the first. The iterable does not include
+     * future writes - writes that happen after its creation.
+     * @return
+     * @throws IOException
+     */
     public Iterable<Location> undo() throws IOException {
       return new Undo(redo());
     }
 
+    /**
+     * Return an iterable to replay the journal in reverse, starting with the
+     * newest location and ending with the specified end location. The iterable
+     * does not include future writes - writes that happen after its creation.
+     * @param end
+     * @return
+     * @throws IOException
+     */
     public Iterable<Location> undo(Location end) throws IOException {
       return new Undo(redo(end));
     }

--- a/src/main/java/journal/io/api/Journal.java
+++ b/src/main/java/journal/io/api/Journal.java
@@ -286,6 +286,10 @@ public class Journal {
       return new Undo(redo());
     }
 
+    public Iterable<Location> undo(Location end) throws IOException {
+      return new Undo(redo(end));
+    }
+
     /**
      * Get the files part of this journal.
      * @return

--- a/src/main/java/journal/io/api/Journal.java
+++ b/src/main/java/journal/io/api/Journal.java
@@ -728,21 +728,21 @@ public class Journal {
         private final int start;
   
         public Undo(Iterable<Location> redo) {
-            // Object arrays of 14 are about the size of a cache-line (64 bytes)
+            // Object arrays of 12 are about the size of a cache-line (64 bytes)
             // or two, depending on the oops-size.
-            Object[] stack = new Object[14];
+            Object[] stack = new Object[12];
             // the last element of the arrays refer to the next "fat node."
             // the last element of the last node is null as an end-mark
-            int pointer = 12;
+            int pointer = 10;
             Iterator<Location> itr = redo.iterator();
             while (itr.hasNext()) {
                 Location location = itr.next();
                 stack[pointer] = location;
                 if (pointer == 0) {
-                    Object[] tmp = new Object[14];
-                    tmp[13] = stack;
+                    Object[] tmp = new Object[12];
+                    tmp[11] = stack;
                     stack = tmp;
-                    pointer = 12;
+                    pointer = 10;
                 } else {
                     pointer--;
                 }

--- a/src/main/java/journal/io/api/Journal.java
+++ b/src/main/java/journal/io/api/Journal.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.Iterator;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.io.File;
 import java.io.FilenameFilter;
@@ -265,7 +266,11 @@ public class Journal {
      * @return
      */
     public Iterable<Location> redo() throws IOException {
-        return new Redo(goToFirstLocation(dataFiles.firstEntry().getValue(), Location.USER_RECORD_TYPE, true));
+        Entry<Integer, DataFile> firstEntry = dataFiles.firstEntry();
+        if (firstEntry == null) {
+            return new Redo(null);
+        }
+        return new Redo(goToFirstLocation(firstEntry.getValue(), Location.USER_RECORD_TYPE, true));
     }
 
     /**
@@ -740,12 +745,12 @@ public class Journal {
       
                 @Override
                 public Location next() {
-                    if (ref == null) {
-                        throw new NoSuchElementException();
-                    }
                     Object next = ref[pointer];
                     if (!(ref[pointer] instanceof Location)) {
                         ref = (Object[]) ref[pointer];
+                        if (ref == null) {
+                          throw new NoSuchElementException();
+                        }
                         pointer = 0;
                         return next();
                     }

--- a/src/test/java/journal/io/api/JournalTest.java
+++ b/src/test/java/journal/io/api/JournalTest.java
@@ -93,49 +93,73 @@ public class JournalTest {
     }
     
     @Test
+    public void testRedoOnEmptyJournal() throws Exception {
+        Iterator<Location> itr = journal.redo().iterator();
+        assertFalse(itr.hasNext());
+        try {
+            itr.next();
+            fail("should have thrown");
+        } catch (Exception e) {
+            assertTrue(e instanceof NoSuchElementException);
+        }
+    }
+    
+    @Test
     public void testUndoMustTraverseLogInReverseOrder() throws Exception {
-      journal.write("DATA1".getBytes("UTF-8"), false);
-      journal.write("DATA2".getBytes("UTF-8"), false);
-      journal.write("DATA3".getBytes("UTF-8"), false);
-      Iterator<Location> itr = journal.undo().iterator();
-      assertTrue(itr.hasNext());
-      assertEquals("DATA3", new String(journal.read(itr.next(), false), "UTF-8"));
-      assertEquals("DATA2", new String(journal.read(itr.next(), false), "UTF-8"));
-      assertEquals("DATA1", new String(journal.read(itr.next(), false), "UTF-8"));
-      assertFalse(itr.hasNext());
+        journal.write("DATA1".getBytes("UTF-8"), false);
+        journal.write("DATA2".getBytes("UTF-8"), false);
+        journal.write("DATA3".getBytes("UTF-8"), false);
+        Iterator<Location> itr = journal.undo().iterator();
+        assertTrue(itr.hasNext());
+        assertEquals("DATA3", new String(journal.read(itr.next(), false), "UTF-8"));
+        assertEquals("DATA2", new String(journal.read(itr.next(), false), "UTF-8"));
+        assertEquals("DATA1", new String(journal.read(itr.next(), false), "UTF-8"));
+        assertFalse(itr.hasNext());
     }
     
     @Test
     public void testUndoDoesNotTakeNewWritesIntoAccount() throws Exception {
-      journal.write("A".getBytes("UTF-8"), false);
-      journal.write("B".getBytes("UTF-8"), false);
-      Iterable<Location> undo = journal.undo();
-      journal.write("C".getBytes("UTF-8"), false);
-      Iterator<Location> locs = undo.iterator();
-      assertEquals("B", new String(journal.read(locs.next(), false), "UTF-8"));
-      assertEquals("A", new String(journal.read(locs.next(), false), "UTF-8"));
-      assertFalse(locs.hasNext());
+        journal.write("A".getBytes("UTF-8"), false);
+        journal.write("B".getBytes("UTF-8"), false);
+        Iterable<Location> undo = journal.undo();
+        journal.write("C".getBytes("UTF-8"), false);
+        Iterator<Location> locs = undo.iterator();
+        assertEquals("B", new String(journal.read(locs.next(), false), "UTF-8"));
+        assertEquals("A", new String(journal.read(locs.next(), false), "UTF-8"));
+        assertFalse(locs.hasNext());
     }
     
     @Test
     public void testUndoingLargeChunkOfData() throws Exception {
-      byte parts = 127;
-      for (byte i = 0; i < parts; i++) {
-        journal.write(new byte[] {i}, false);
-      }
-      Iterator<Location> locs = journal.undo().iterator();
-      while (parts > 0) {
-        Location loc = locs.next();
-        assertArrayEquals(new byte[] {--parts}, journal.read(loc));
-      }
+        byte parts = 127;
+        for (byte i = 0; i < parts; i++) {
+            journal.write(new byte[] {i}, false);
+        }
+        Iterator<Location> locs = journal.undo().iterator();
+        while (parts > 0) {
+            Location loc = locs.next();
+            assertArrayEquals(new byte[] {--parts}, journal.read(loc));
+        }
     }
     
     @Test(expected = NoSuchElementException.class)
     public void testUndoingPastStartWillThrowException() throws Exception {
-      journal.write(new byte[] {1}, false);
-      Iterator<Location> itr = journal.undo().iterator();
-      itr.next();
-      itr.next();
+        journal.write(new byte[] {1}, false);
+        Iterator<Location> itr = journal.undo().iterator();
+        itr.next();
+        itr.next();
+    }
+    
+    @Test
+    public void testUndoingAnEmptyJournal() throws Exception {
+        Iterator<Location> itr = journal.undo().iterator();
+        assertFalse(itr.hasNext());
+        try {
+            itr.next();
+            fail("should have thrown");
+        } catch (Exception e) {
+            assertTrue(e instanceof NoSuchElementException);
+        }
     }
     // TODO the same undo tests but with a specified start location
     // TODO deleting through the undo iterator

--- a/src/test/java/journal/io/api/JournalTest.java
+++ b/src/test/java/journal/io/api/JournalTest.java
@@ -13,6 +13,8 @@
  */
 package journal.io.api;
 
+import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.io.File;
@@ -89,6 +91,54 @@ public class JournalTest {
             assertEquals("DATA" + i++, new String(buffer, "UTF-8"));
         }
     }
+    
+    @Test
+    public void testUndoMustTraverseLogInReverseOrder() throws Exception {
+      journal.write("DATA1".getBytes("UTF-8"), false);
+      journal.write("DATA2".getBytes("UTF-8"), false);
+      journal.write("DATA3".getBytes("UTF-8"), false);
+      Iterator<Location> itr = journal.undo().iterator();
+      assertTrue(itr.hasNext());
+      assertEquals("DATA3", new String(journal.read(itr.next(), false), "UTF-8"));
+      assertEquals("DATA2", new String(journal.read(itr.next(), false), "UTF-8"));
+      assertEquals("DATA1", new String(journal.read(itr.next(), false), "UTF-8"));
+      assertFalse(itr.hasNext());
+    }
+    
+    @Test
+    public void testUndoDoesNotTakeNewWritesIntoAccount() throws Exception {
+      journal.write("A".getBytes("UTF-8"), false);
+      journal.write("B".getBytes("UTF-8"), false);
+      Iterable<Location> undo = journal.undo();
+      journal.write("C".getBytes("UTF-8"), false);
+      Iterator<Location> locs = undo.iterator();
+      assertEquals("B", new String(journal.read(locs.next(), false), "UTF-8"));
+      assertEquals("A", new String(journal.read(locs.next(), false), "UTF-8"));
+      assertFalse(locs.hasNext());
+    }
+    
+    @Test
+    public void testUndoingLargeChunkOfData() throws Exception {
+      byte parts = 127;
+      for (byte i = 0; i < parts; i++) {
+        journal.write(new byte[] {i}, false);
+      }
+      Iterator<Location> locs = journal.undo().iterator();
+      while (parts > 0) {
+        Location loc = locs.next();
+        assertArrayEquals(new byte[] {--parts}, journal.read(loc));
+      }
+    }
+    
+    @Test(expected = NoSuchElementException.class)
+    public void testUndoingPastStartWillThrowException() throws Exception {
+      journal.write(new byte[] {1}, false);
+      Iterator<Location> itr = journal.undo().iterator();
+      itr.next();
+      itr.next();
+    }
+    // TODO the same undo tests but with a specified start location
+    // TODO deleting through the undo iterator
 
     @Test
     public void testMixedSyncAsyncLogWritingAndReplaying() throws Exception {

--- a/src/test/java/journal/io/api/JournalTest.java
+++ b/src/test/java/journal/io/api/JournalTest.java
@@ -130,7 +130,7 @@ public class JournalTest {
     }
     
     @Test
-    public void testUndoingLargeChunkOfData() throws Exception {
+    public void testUndoingLargeChunksOfData() throws Exception {
         byte parts = 127;
         for (byte i = 0; i < parts; i++) {
             journal.write(new byte[] {i}, false);
@@ -161,7 +161,27 @@ public class JournalTest {
             assertTrue(e instanceof NoSuchElementException);
         }
     }
-    // TODO the same undo tests but with a specified start location
+    
+    @Test
+    public void testUndoingFromLastWriteIteratesOneLocation() throws Exception {
+      Location loc = journal.write(new byte[] {23}, false);
+      Iterator<Location> itr = journal.undo(loc).iterator();
+      assertArrayEquals(new byte[] {23}, journal.read(itr.next()));
+      assertFalse(itr.hasNext());
+    }
+    
+    @Test
+    public void testUndoIteratorStopsAtEnd() throws Exception {
+      journal.write(new byte[] {11}, false);
+      Location end = journal.write(new byte[] {12}, false);
+      journal.write(new byte[] {13}, false);
+      Iterator<Location> itr = journal.undo(end).iterator();
+      assertArrayEquals(new byte[] {13}, journal.read(itr.next()));
+      assertArrayEquals(new byte[] {12}, journal.read(itr.next()));
+      assertFalse(itr.hasNext());
+    }
+    
+    
     // TODO deleting through the undo iterator
 
     @Test


### PR DESCRIPTION
In addition to implementing the `undo` APIs as discussed, a bug in `redo()` on an empty journal has been fixed, and the `Redo` class has been made private.
