### PR TITLE
Fix journal redo and recovery bug

### DIFF
--- a/src/test/java/journal/io/api/JournalTest.java
+++ b/src/test/java/journal/io/api/JournalTest.java
@@ -657,6 +657,7 @@ public class JournalTest {
             byte[] buffer = newJournal.read(location, Journal.ReadType.ASYNC);
             assertEquals("DATA" + i++, new String(buffer, "UTF-8"));
         }
+        assertEquals(30, i);
     }
 
     protected void configure(Journal journal) {

--- a/src/test/java/journal/io/api/JournalTest.java
+++ b/src/test/java/journal/io/api/JournalTest.java
@@ -638,6 +638,27 @@ public class JournalTest {
         assertEquals(iterations - (iterations / 4), locations);
     }
 
+    @Test
+    public void testRedoWithNewJournalInstance() throws Exception {
+        int iterations = 30;
+        for (int i = 0; i < iterations; i++) {
+            journal.write(new String("DATA" + i).getBytes("UTF-8"), Journal.WriteType.SYNC);
+        }
+
+        journal.close();
+
+        Journal newJournal = new Journal();
+        newJournal.setDirectory(dir);
+        configure(newJournal);
+        newJournal.open();
+
+        int i = 0;
+        for (Location location : newJournal.redo()) {
+            byte[] buffer = newJournal.read(location, Journal.ReadType.ASYNC);
+            assertEquals("DATA" + i++, new String(buffer, "UTF-8"));
+        }
+    }
+
     protected void configure(Journal journal) {
         journal.setMaxFileLength(1024);
         journal.setMaxWriteBatchSize(1024);


### PR DESCRIPTION
Hi Sergio,

this pull request fixes two issues that I found when using a new Journal instance with existing data files. 
- Redo didn't work because the data files weren't linked properly after loading. 
- After fixing this linking error I found that the first entry in data files n > 1 cause a checksum error. This is because goToNextLocation(..., ..., boolean true) doesn't behave as recoveryCheck() expected i.e. it doesn't return a batch control record when switching to a new data file which was required by the former recoveryCheck() implementation. Instead it returns the first record after the batch control record which caused recoveryCheck() to compute a wrong checksum. This is now fixed by looping over the data files 'manually' and not via goToNextLocation(...). I initially tried to fix that in goToNextLocation but found that this breaks other existing functionality.

Cheers,
Martin
