### PR TITLE
use oss.s.o maven repository in order to get sync to central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+      <groupId>org.sonatype.oss</groupId>
+      <artifactId>oss-parent</artifactId>
+      <version>7</version>
+    </parent>
 
     <groupId>journalio</groupId>
     <artifactId>journalio</artifactId>
@@ -42,16 +47,20 @@
             <timezone>GMT-5</timezone>
         </developer>
     </developers>
-    <distributionManagement>
-        <repository>
-            <id>journalio-repo</id>
-            <name>journalio-repo</name>
-            <url>file:m2/repo</url>
-        </repository>
-    </distributionManagement>
     <scm>
-        <developerConnection>scm:git:ssh://git@github.com/sbtourist/Journal.IO.git</developerConnection>
+      <connection>scm:git:git@github.com:sbtourist/Journal.IO.git</connection>
+      <developerConnection>scm:git:git@github.com:sbtourist/Journal.IO.git</developerConnection>
+      <url>git@github.com:sbtourist/Journal.IO.git</url>
     </scm>
+    <url>https://github.com/sbtourist/Journal.IO</url>
+    <licenses>
+      <license>
+        <name>The Apache Software License, Version 2.0</name>
+        <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        <distribution>repo</distribution>
+      </license>
+    </licenses>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Pull request to make POM changes needed to deploy to oss.sonatype.org which will sync to maven central.

See the [singup docs](https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide#SonatypeOSSMavenRepositoryUsageGuide-2.Signup) for the final steps to get perms to push, etc. 
