### PR TITLE
Make generated jar an OSGI bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>journalio</groupId>
     <artifactId>journalio</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <version>1.3-SNAPSHOT</version>
 
     <name>Journal.IO</name>
@@ -84,6 +84,17 @@
                     <downloadSources>true</downloadSources>
                     <downloadJavadocs>true</downloadJavadocs>
                     <useProjectReferences>false</useProjectReferences>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>journal.io.*</Export-Package>
+                    </instructions>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/journal/io/api/DataFileAppender.java
+++ b/src/main/java/journal/io/api/DataFileAppender.java
@@ -21,6 +21,7 @@ import java.io.InterruptedIOException;
 import java.io.RandomAccessFile;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -93,7 +94,11 @@ class DataFileAppender {
                             signalBatch();
                             nextWriteBatch = null;
                         } else {
-                            result = new WriteFuture(journal.getLastAppendLocation().getLatch());
+                            final CountDownLatch latch = journal.getLastAppendLocation().getLatch();
+                            if (latch != null) {
+                                result = new WriteFuture(latch);
+                            }
+                            //Nothing written yet, return null
                         }
                         return result;
                     } finally {

--- a/src/main/java/journal/io/api/Journal.java
+++ b/src/main/java/journal/io/api/Journal.java
@@ -262,7 +262,10 @@ public class Journal {
      */
     public void sync() throws IOException {
         try {
-            appender.sync().get();
+            final Future<Boolean> sync = appender.sync();
+            if (sync != null) {
+                sync.get();
+            }
             if (appender.getAsyncException() != null) {
                 throw new IOException(appender.getAsyncException());
             }


### PR DESCRIPTION
Having Journal.IO jar being an OSGI bundle would ease OSGI integration. Change is quite straightforward and has no impact for non OSGI users.
