### PR TITLE
Publish sources along with primary artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,20 @@
                     <useProjectReferences>false</useProjectReferences>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <dependencies>


### PR DESCRIPTION
The -sources.jar isn't currently created by the build. This change adds the maven-source-plugin to create the sources jar for publishing.
