### PR TITLE
Data file leaks lead to test failures

### DIFF
--- a/src/main/java/journal/io/api/DataFileAccessor.java
+++ b/src/main/java/journal/io/api/DataFileAccessor.java
@@ -192,6 +192,7 @@ class DataFileAccessor {
             for (Entry<Integer, RandomAccessFile> raf : threadRafs.getValue().entrySet()) {
                 if (raf.getKey().equals(dataFileId)) {
                     dispose(threadRafs.getKey(), dataFileId);
+                    break;
                 }
             }
         }

--- a/src/main/java/journal/io/api/DataFileAccessor.java
+++ b/src/main/java/journal/io/api/DataFileAccessor.java
@@ -187,21 +187,25 @@ class DataFileAccessor {
     }
 
     void dispose(DataFile dataFile) {
+        Integer dataFileId = dataFile.getDataFileId();
         for (Entry<Thread, ConcurrentMap<Integer, RandomAccessFile>> threadRafs : perThreadDataFileRafs.entrySet()) {
             for (Entry<Integer, RandomAccessFile> raf : threadRafs.getValue().entrySet()) {
-                if (raf.getKey().equals(dataFile.getDataFileId())) {
-                    Lock lock = getOrCreateLock(threadRafs.getKey(), raf.getKey());
-                    lock.lock();
-                    try {
-                        removeRaf(threadRafs.getKey(), raf.getKey());
-                        return;
-                    } catch (IOException ex) {
-                        warn(ex, ex.getMessage());
-                    } finally {
-                        lock.unlock();
-                    }
+                if (raf.getKey().equals(dataFileId)) {
+                    dispose(threadRafs.getKey(), dataFileId);
                 }
             }
+        }
+    }
+
+    private void dispose(Thread t, Integer dataFileId) {
+        Lock lock = getOrCreateLock(t, dataFileId);
+        lock.lock();
+        try {
+            removeRaf(t, dataFileId);
+        } catch (IOException ex) {
+            warn(ex, ex.getMessage());
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -211,7 +215,11 @@ class DataFileAccessor {
     }
 
     void close() {
-        // No-op as of now...
+        for (Entry<Thread, ConcurrentMap<Integer, RandomAccessFile>> threadRafs : perThreadDataFileRafs.entrySet()) {
+            for (Entry<Integer, RandomAccessFile> raf : threadRafs.getValue().entrySet()) {
+                dispose(threadRafs.getKey(), raf.getKey());
+            }
+        }
     }
 
     void pause() {

--- a/src/test/java/journal/io/api/AbstractJournalTest.java
+++ b/src/test/java/journal/io/api/AbstractJournalTest.java
@@ -17,6 +17,7 @@ import java.io.File;
 import journal.io.api.Journal;
 import org.junit.After;
 import org.junit.Before;
+import static org.junit.Assert.*;
 
 /**
  * @author Sergio Bossa
@@ -46,7 +47,9 @@ public abstract class AbstractJournalTest {
     public void tearDown() throws Exception {
         journal.close();
         deleteFilesInDirectory(dir);
-        dir.delete();
+        if (!dir.delete()) {
+            fail("Failed to delete: " + dir.getName());
+        }
     }
 
     protected void configure(Journal journal) {
@@ -55,6 +58,7 @@ public abstract class AbstractJournalTest {
     }
 
     protected void postSetUp() {
+        // stub
     }
 
     protected final void deleteFilesInDirectory(File directory) {
@@ -65,7 +69,9 @@ public abstract class AbstractJournalTest {
                 if (f.isDirectory()) {
                     deleteFilesInDirectory(f);
                 }
-                f.delete();
+                if (!f.delete()) {
+                    fail("Failed to delete: " + f.getName());
+                }
             }
         }
     }


### PR DESCRIPTION
First commit merely adds asserts which will probably only ever fire under Windows. Second commit adds actual logic to close files in DataFileAccessor.close(), which is called by Journal.close().
