### PR TITLE
Fix data leaks due to free-flying Journal instances

### DIFF
--- a/src/test/java/journal/io/api/AbstractJournalTest.java
+++ b/src/test/java/journal/io/api/AbstractJournalTest.java
@@ -45,6 +45,7 @@ public abstract class AbstractJournalTest {
 
     @After
     public void tearDown() throws Exception {
+        preTearDown();
         journal.close();
         deleteFilesInDirectory(dir);
         if (!dir.delete()) {
@@ -57,7 +58,11 @@ public abstract class AbstractJournalTest {
         journal.setMaxWriteBatchSize(1024);
     }
 
-    protected void postSetUp() {
+    protected void postSetUp() throws Exception {
+        // stub
+    }
+
+    protected void preTearDown() throws Exception {
         // stub
     }
 

--- a/src/test/java/journal/io/api/ConcurrencyTest.java
+++ b/src/test/java/journal/io/api/ConcurrencyTest.java
@@ -169,9 +169,4 @@ public class ConcurrencyTest extends AbstractJournalTest {
         assertEquals(iterations - deletions, iterationsCounter.get());
     }
 
-    @Override
-    protected void configure(Journal journal) {
-        journal.setMaxFileLength(1024);
-        journal.setMaxWriteBatchSize(1024);
-    }
 }

--- a/src/test/java/journal/io/api/ReadWriteTest.java
+++ b/src/test/java/journal/io/api/ReadWriteTest.java
@@ -14,6 +14,8 @@
 package journal.io.api;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
@@ -117,8 +119,8 @@ public class ReadWriteTest extends AbstractJournalTest {
     public void testWriteCallbackOnSync() throws Exception {
         final int iterations = 10;
         final CountDownLatch writeLatch = new CountDownLatch(iterations);
+        final Map<Location, Throwable> errors = new HashMap<Location, Throwable>();
         WriteCallback callback = new WriteCallback() {
-
             @Override
             public void onSync(Location syncedLocation) {
                 writeLatch.countDown();
@@ -126,6 +128,7 @@ public class ReadWriteTest extends AbstractJournalTest {
 
             @Override
             public void onError(Location location, Throwable error) {
+                errors.put(location, error);
             }
         };
         for (int i = 0; i < iterations; i++) {
@@ -133,6 +136,7 @@ public class ReadWriteTest extends AbstractJournalTest {
         }
         journal.sync();
         assertTrue(writeLatch.await(5, TimeUnit.SECONDS));
+        assertTrue("Caught errors: " + errors, errors.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
As discussed: with these changes all tests reliably & repeatably pass, both in eclipse and maven. Changes to the test superclass were minimal and while I'm not super-happy with the duplication of test setup/teardown logic it is symmetric, allows per-test isolation with minimum effort and works.
IMHO it would be less fragile to only create the directory & do cleanup in the superclass, and always have each test class create/open/close the per-test Journal it needs individually.
