### PR TITLE
Compaction temp file shouldnt match regular log file names

### DIFF
--- a/src/main/java/journal/io/api/Journal.java
+++ b/src/main/java/journal/io/api/Journal.java
@@ -810,7 +810,7 @@ public class Journal {
 
     private void compactDataFile(DataFile currentFile, Location firstUserLocation) throws IOException {
         DataFile tmpFile = new DataFile(
-                new File(currentFile.getFile().getParent(), filePrefix + currentFile.getDataFileId() + ".tmp" + fileSuffix),
+                new File(currentFile.getFile().getParent(), filePrefix + currentFile.getDataFileId() + fileSuffix + ".tmp"),
                 currentFile.getDataFileId());
         tmpFile.writeHeader();
         RandomAccessFile raf = tmpFile.openRandomAccessFile();


### PR DESCRIPTION
Create temporary compaction target file to be prefix<num>.log.tmp
instead of prefix<num>.tmp.log

Prevents NumberFormatException on open if we happened to die mid
compaction as it will no longer match the FilenameFilter on open.
